### PR TITLE
Remove non-existent export

### DIFF
--- a/app/helpers/unique-id.js
+++ b/app/helpers/unique-id.js
@@ -1,4 +1,1 @@
-export {
-  default,
-  uniqueId,
-} from 'ember-unique-id-helper-polyfill/helpers/unique-id';
+export { default } from 'ember-unique-id-helper-polyfill/helpers/unique-id';


### PR DESCRIPTION
Embroider reports that uniqueId doesn't exist and it's not part of
addon/helpers/unique-id so I've changed this to only re-export only
default.


```
WARNING in ./helpers/unique-id.js 1:0-108
export 'uniqueId' (reexported as 'uniqueId') was not found in '../../../node_modules/ember-unique-id-helper-polyfill/helpers/unique-id' (possible exports: default)
```