### PR TITLE
Remove `ember-auto-import` from `Compatibility` section in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Compatibility
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
 * Node.js v12 or above
-* ember-auto-import v2 or above
 
 
 Installation


### PR DESCRIPTION
`ember-auto-import` v2 is not required as it's [listed as a dev dependency](https://github.com/ctjhoa/ember-unique-id-helper-polyfill/blob/master/package.json#L43).