### PR TITLE
Move `ember-cli-htmlbars` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.10",
-    "ember-cli-htmlbars": "^5.7.2"
+    "ember-cli-babel": "^7.26.10"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -43,6 +42,7 @@
     "ember-auto-import": "^2.4.0",
     "ember-cli": "~3.28.5",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.7.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",


### PR DESCRIPTION
`ember-cli-htmlbars` is only needed under `dependencies` when templates are shipped, which is not the case for this addon.