### PR TITLE
Make sure unique ids always start with a letter

### DIFF
--- a/addon/helpers/unique-id.js
+++ b/addon/helpers/unique-id.js
@@ -2,9 +2,10 @@ import { helper } from '@ember/component/helper';
 
 export default helper(uniqueId);
 
-// Copy-pasted from the ember-source implementation: https://github.com/emberjs/ember.js/pull/19882
+// Copy-pasted from the ember-source implementation:
+// https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/glimmer/lib/helpers/unique-id.ts
 function uniqueId() {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (a) =>
-    (a ^ ((Math.random() * 16) >> (a / 4))).toString(16)
+  return ([3e7] + -1e3 + -4e3 + -2e3 + -1e11).replace(/[0-3]/g, (a) =>
+    ((a * 4) ^ ((Math.random() * 16) >> (a & 2))).toString(16)
   );
 }

--- a/tests/integration/helpers/unique-id-test.js
+++ b/tests/integration/helpers/unique-id-test.js
@@ -17,4 +17,19 @@ module('Integration | Helper | unique-id', function (hooks) {
 
     assert.notEqual(firstId, secondId);
   });
+
+  test('it only generates unique ids that start with a letter', async function (assert) {
+    let iterations = 1000;
+    let regExpLetterStart = /^[a-z]/;
+
+    assert.expect(iterations);
+
+    for (let i = 0; i < iterations; i++) {
+      await render(hbs`{{unique-id}}`);
+
+      let uniqueId = this.element.textContent.trim();
+
+      assert.true(regExpLetterStart.test(uniqueId));
+    }
+  });
 });


### PR DESCRIPTION
This makes sure they can be used directly as an id selector.

Closes #7.