### PR TITLE
Display a normal warning instead of a deprecation warning when the `unique-id` helper is natively available

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
       let message =
         'The `{{unique-id}}` helper is available natively since Ember 4.4.0-beta.1. You can remove `ember-unique-id-helper-polyfill` from your `package.json`.';
 
-      this.ui.writeDeprecateLine(message);
+      this.ui.writeWarnLine(message);
     }
   },
 


### PR DESCRIPTION
Otherwise, this makes it seem like the polyfill itself is deprecated, which isn't the case.

Will display:
```
WARNING: The `{{unique-id}}` helper is available natively since Ember 4.4.0-beta.1. You can remove `ember-unique-id-helper-polyfill` from your `package.json`.
```